### PR TITLE
fixed query route and added namespaces parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparql-notebook",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sparql-notebook",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "url": "https://github.com/zazuko/vscode-sparql-notebook.git"
   },
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "vscode": "^1.62.0"
   },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,19 @@
           "contextualTitle": "Connections"
         }
       ]
-    }
+    },
+    "configuration":[
+      {
+        "title": "SPARQL Notebook",
+        "properties": {
+          "sparqlbook.useNamespaces":{
+            "type": "boolean",
+            "default": false,
+            "description": "Format output using prefixes from query."
+          }
+        }
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension/simple-client.ts
+++ b/src/extension/simple-client.ts
@@ -31,7 +31,7 @@ export class SparqlClient {
         Accept: "application/sparql-results+json,text/turtle",
       },
     };
-    const response = await this.endpoint.post("/", params, config);
+    const response = await this.endpoint.post("", params, config);
     return response;
   }
 }

--- a/src/extension/sparql-notebook-controller.ts
+++ b/src/extension/sparql-notebook-controller.ts
@@ -56,8 +56,9 @@ export class SparqlNotebookController {
       );
     }
 
+    const query = cell.document.getText();
     const queryResult = await client
-      .query(cell.document.getText())
+      .query(query)
       .catch((error) => {
         execution.replaceOutput([
           new vscode.NotebookCellOutput([
@@ -70,7 +71,43 @@ export class SparqlNotebookController {
 
     // content type
     const contentType = queryResult.headers["content-type"].split(";")[0];
-    const data = queryResult.data;
+    let data = queryResult.data;
+
+    // get namespaces
+    let namespaces: any = {};
+    let nsRegex = /[Pp][Rr][Ee][Ff][Ii][Xx] ([^:]*):[ ]*<([^>]*)>/g;
+    var m: any = true;
+    do {
+      m = nsRegex.exec(query);
+      if (m) {
+        namespaces[m[1]] = m[2];
+      }
+    } while (m);
+    console.log("found namespaces", namespaces);
+
+    // format namespaces
+    let bindings: any[] = data.results.bindings;
+    bindings = bindings.map(triple => {
+      const variables = Object.keys(triple);
+
+      for (const variable of variables) {
+        const tripleVariable = triple[variable];
+
+        if (tripleVariable.type == "uri") {
+          for (const namespace of Object.keys(namespaces)) {
+            const newValue = tripleVariable.value.replace(namespaces[namespace], namespace + ":");
+            if (newValue != tripleVariable.value) {
+              tripleVariable.value = newValue;
+              break;
+            }
+          }
+        }
+
+        triple[variable] = tripleVariable;
+      }
+      return triple;
+    })
+    data.results.bindings = bindings;
 
     if (contentType === "application/sparql-results+json") {
       // sparql ask or select
@@ -139,5 +176,5 @@ export class SparqlNotebookController {
     return endpoints.shift();
   }
 
-  dispose() {}
+  dispose() { }
 }

--- a/src/extension/sparql-notebook-controller.ts
+++ b/src/extension/sparql-notebook-controller.ts
@@ -71,43 +71,7 @@ export class SparqlNotebookController {
 
     // content type
     const contentType = queryResult.headers["content-type"].split(";")[0];
-    let data = queryResult.data;
-
-    // get namespaces
-    let namespaces: any = {};
-    let nsRegex = /[Pp][Rr][Ee][Ff][Ii][Xx] ([^:]*):[ ]*<([^>]*)>/g;
-    var m: any = true;
-    do {
-      m = nsRegex.exec(query);
-      if (m) {
-        namespaces[m[1]] = m[2];
-      }
-    } while (m);
-    console.log("found namespaces", namespaces);
-
-    // format namespaces
-    let bindings: any[] = data.results.bindings;
-    bindings = bindings.map(triple => {
-      const variables = Object.keys(triple);
-
-      for (const variable of variables) {
-        const tripleVariable = triple[variable];
-
-        if (tripleVariable.type == "uri") {
-          for (const namespace of Object.keys(namespaces)) {
-            const newValue = tripleVariable.value.replace(namespaces[namespace], namespace + ":");
-            if (newValue != tripleVariable.value) {
-              tripleVariable.value = newValue;
-              break;
-            }
-          }
-        }
-
-        triple[variable] = tripleVariable;
-      }
-      return triple;
-    })
-    data.results.bindings = bindings;
+    const data = this._parseNamespacesAndFormatBindings(queryResult.data, query);
 
     if (contentType === "application/sparql-results+json") {
       // sparql ask or select
@@ -174,6 +138,50 @@ export class SparqlNotebookController {
       return true;
     });
     return endpoints.shift();
+  }
+
+  private _parseNamespacesAndFormatBindings(data: any, query: string): any {
+    const configuration = vscode.workspace.getConfiguration('sparqlbook');
+    const useNamespaces = configuration.get("useNamespaces");
+    if (!useNamespaces) { return data; }
+
+    // get namespaces from prefixes in query
+    let namespaces: any = {};
+    let nsRegex = /[Pp][Rr][Ee][Ff][Ii][Xx] ([^:]*):[ ]*<([^>]*)>/g;
+    var m: any = true;
+    do {
+      m = nsRegex.exec(query);
+      if (m) {
+        namespaces[m[1]] = m[2];
+      }
+    } while (m);
+
+    // format uri in triples using namespaces
+    let bindings: any[] = data.results.bindings;
+    bindings = bindings.map(triple => {
+      const variables = Object.keys(triple);
+
+      for (const variable of variables) {
+        const tripleVariable = triple[variable];
+
+        if (tripleVariable.type === "uri") {
+          for (const namespace of Object.keys(namespaces)) {
+            const newValue = tripleVariable.value.replace(namespaces[namespace], namespace + ":");
+
+            if (newValue !== tripleVariable.value) {
+              tripleVariable.value = newValue;
+              break;
+            }
+          }
+        }
+
+        triple[variable] = tripleVariable;
+      }
+      return triple;
+    });
+
+    data.results.bindings = bindings;
+    return data;
   }
 
   dispose() { }


### PR DESCRIPTION
Query POST created invalid route for this sparql database: [Oxigraph](https://github.com/oxigraph/oxigraph).

Instead of posting on this route 'http://localhost:7878/query', 
it was posting on this 'http://localhost:7878/query/' which resulted in 404 in Oxigraph database.

I also added parsing of namespaces from query prefixes.
You can enable it using this line in settings `"sparqlbook.useNamespaces": true` and it will format the output.