### PR TITLE
refactors simple-client.ts such that only one type of request heade is sent, depending on the type of query

### DIFF
--- a/src/extension/sparql-client/simple-client.ts
+++ b/src/extension/sparql-client/simple-client.ts
@@ -27,7 +27,7 @@ export class SparqlClient {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'Content-Type': 'application/x-www-form-urlencoded',
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        Accept: 'application/sparql-results+json,text/turtle',
+        Accept: sparqlQuery.toLowerCase().includes("construct") ? 'text/turtle' : 'application/sparql-results+json',
       },
       signal: abortController.signal
     };


### PR DESCRIPTION

some SPARQL endpoint (e.g. https://github.com/vemonet/rdflib-endpoint) can't handle combined Accept headers like "application/sparql-results+json,text/turtle" and will return their default  (xml in this case) instead. the proposed refactoring uses only one type, depending of the type of query used. 

there's probably a more elegant and future proof way of doing that, but this does the job in most of the cases too