### PR TITLE
query and update via HTTP POST directly

### DIFF
--- a/src/extension/endpoint/http-endpoint/http-endpoint.ts
+++ b/src/extension/endpoint/http-endpoint/http-endpoint.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
-import { getAcceptHeader } from '../sparql-utils';
+import { getAcceptHeader, getContentTypeHeader } from '../sparql-utils';
 import { Endpoint, SimpleHttpResponse } from '../endpoint';
 import { SparqlQuery } from '../model/sparql-query';
 import { MimeType } from '../../enum/mime-type';
@@ -45,16 +45,13 @@ export class HttpEndpoint extends Endpoint {
    * @param execution - The execution object.
    */
   public async query(sparqlQuery: SparqlQuery, execution?: any): Promise<SimpleHttpResponse> {
-    const params = new URLSearchParams();
-    params.append("query", sparqlQuery.queryString);
-
     const abortController = new AbortController();
     const queryKind = sparqlQuery.kind;
 
     const options: AxiosRequestConfig = {
       headers: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': getContentTypeHeader(queryKind),
         // eslint-disable-next-line @typescript-eslint/naming-convention
         Accept: getAcceptHeader(queryKind),
       },
@@ -66,7 +63,7 @@ export class HttpEndpoint extends Endpoint {
         abortController.abort();
       });
     }
-    const response = await this.http.post('', params, options);
+    const response = await this.http.post('', sparqlQuery.queryString, options);
     const mimeType = response.headers['content-type'];
 
     const httpResponse: SimpleHttpResponse = {

--- a/src/extension/endpoint/sparql-utils.ts
+++ b/src/extension/endpoint/sparql-utils.ts
@@ -74,3 +74,24 @@ export function getAcceptHeader(queryType: SPARQLQueryKind): MimeType {
             throw new Error('Unknown query type' + queryType);
     }
 }
+
+
+export function getContentTypeHeader(queryType: SPARQLQueryKind): MimeType {
+    switch (queryType) {
+        case SPARQLQueryKind.ask:
+        case SPARQLQueryKind.select:
+        case SPARQLQueryKind.construct:
+        case SPARQLQueryKind.describe:
+        case SPARQLQueryKind.json:
+            return MimeType.sparqlQuery
+        case SPARQLQueryKind.insert:
+        case SPARQLQueryKind.delete:
+        case SPARQLQueryKind.load:
+        case SPARQLQueryKind.clear:
+        case SPARQLQueryKind.drop:
+        case SPARQLQueryKind.create:
+            return MimeType.sparqlUpdate
+        default:
+            throw new Error('Unknown query type' + queryType);
+    }
+}

--- a/src/extension/enum/mime-type.ts
+++ b/src/extension/enum/mime-type.ts
@@ -9,6 +9,8 @@ export enum MimeType {
     sparqlResultsXml = 'application/sparql-results+xml',
     sparqlResultsCsv = 'text/csv',
     sparqlResultsTsv = 'text/tab-separated-values',
+    sparqlQuery = 'application/sparql-query',
+    sparqlUpdate = 'application/sparql-update',
     plainText = 'text/plain',
     any = '*/*',
 }


### PR DESCRIPTION
send protocol requests via the HTTP POST method by including the query or update directly and unencoded as the HTTP request message body