### PR TITLE
Added markdown integration for SPARQL and SHACL code blocks:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test-web
 .vscode-test
 *.vsix
+.idea

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ Use a SPARQL notebook to:
 - Provide hands-on SPARQL training
 - Document data available via SPARQL
 - Validate data via SPARQL
+- Validate RDF data using SHACL shapes
 - Run queries against a SPARQL endpoint
 - Run queries against a local RDF file
+- Execute SPARQL/SHACL code blocks directly from markdown files
 
-This notebook can render SPARQL SELECT results and RDF graphs via SPARQL CONSTRUCT queries.
+This notebook can render SPARQL SELECT results and RDF graphs via SPARQL CONSTRUCT queries. It also supports SHACL validation against remote endpoints.
 
 ![sparql-notebook](https://user-images.githubusercontent.com/8033981/157274845-e722bace-16aa-4055-8a07-0b8fc5a8b112.gif)
 
@@ -33,7 +35,10 @@ This extension is still pretty raw but it works for us [tm]. Bug reports & contr
 - Configure endpoint connections in the SPARQL Notebook side panel.
 - Export a `.sparqlbook` file to Markdown.
 - Attach `.sparql` or `.rq` files to cells.
+- Attach `.shacl` or `.ttl` files for SHACL validation cells.
 - Use a local RDF file as a data source.
+- Validate RDF data using SHACL shapes against remote endpoints (e.g., Apache Jena Fuseki).
+- **Markdown Integration**: Open any `.md` file as a SPARQL Markdown Notebook to execute SPARQL and SHACL code blocks with inline results.
 
 ## Installation
 
@@ -103,6 +108,49 @@ You can attach a query file to a cell. The query file will load and execute when
 
 ### Cell Status Bar
 The cell status bar indicates whether the cell uses a query file.
+
+## Markdown Integration
+
+You can execute SPARQL and SHACL code blocks directly from any markdown file. This is useful for creating executable documentation, tutorials, or README files with runnable examples.
+
+### How to Use
+
+1. Right-click on any `.md` or `.markdown` file
+2. Select **"Open With..."**
+3. Choose **"SPARQL Markdown Notebook"**
+
+The file opens as a notebook where:
+- Regular markdown text becomes markdown cells
+- Code blocks marked with ` ```sparql ` become executable SPARQL cells
+- Code blocks marked with ` ```shacl ` become executable SHACL cells
+- Other code blocks (JavaScript, Python, etc.) remain as markdown
+
+### Example
+
+Create a markdown file with SPARQL code blocks:
+
+````markdown
+# My Query Documentation
+
+This query fetches data:
+
+```sparql
+# [endpoint=https://dbpedia.org/sparql]
+SELECT ?city WHERE { ?city a dbo:City } LIMIT 10
+```
+````
+
+When opened as a SPARQL Markdown Notebook, click the play button to execute the query and see results inline.
+
+### Configuration
+
+The markdown integration is enabled by default. Disable it in settings:
+
+```json
+{
+  "sparqlbook.markdownIntegration.enabled": false
+}
+```
 
 ## FAQ
 

--- a/doc/00_intro.md
+++ b/doc/00_intro.md
@@ -6,9 +6,11 @@ The **SPARQL Notebook for VSCode** extension enables users to run SPARQL queries
 
 ### Key Features
 - **Query Execution on HTTP/HTTPS Endpoints**: Run SPARQL queries directly against remote SPARQL endpoints with HTTP/HTTPS protocols.
-- **Binding Local Query Files to Code Cells**: Bind local `.sparql` or `.rq` files directly to code cells, allowing the contents of these files to be embedded within the notebook cell itself. This approach enables you to develop and document queries in a dedicated file while keeping the query available within the notebook for easy execution. Markdown cells can be used alongside these code cells to add explanations or documentation.
+- **SHACL Validation**: Validate RDF data using SHACL shapes against remote endpoints that support SHACL (e.g., Apache Jena Fuseki). SHACL cells use Turtle syntax and return validation reports.
+- **Markdown Integration**: Execute SPARQL and SHACL code blocks directly from any markdown file. Open markdown files as notebooks to get the full notebook experience with inline results.
+- **Binding Local Query Files to Code Cells**: Bind local `.sparql`, `.rq`, `.shacl`, or `.ttl` files directly to code cells, allowing the contents of these files to be embedded within the notebook cell itself. This approach enables you to develop and document queries in a dedicated file while keeping the query available within the notebook for easy execution. Markdown cells can be used alongside these code cells to add explanations or documentation.
 - **RDF File Querying**: Execute SPARQL queries on local RDF files (e.g., Turtle, RDF-XML) by providing a file path or pattern. This is especially useful when transforming data to RDF format and verifying the output with SPARQL before committing it to a triple store.
-- **Markdown and Code Cells**: Use Markdown cells for explanations and Code cells for SPARQL queries. This format is ideal for creating a rich, interactive documentation environment around your queries.
+- **Markdown and Code Cells**: Use Markdown cells for explanations and Code cells for SPARQL queries or SHACL shapes. This format is ideal for creating a rich, interactive documentation environment around your queries.
 
 While it’s a powerful tool for working with SPARQL and RDF data, the SPARQL Notebook is adaptable to a range of use cases beyond data science. Whether you’re building transformation workflows or simply documenting and testing queries. If there are any features missing for your specific use case, feel free to request them.
 
@@ -138,8 +140,124 @@ You can also bind local `.sparql` or `.rq` files to code cells. This is useful i
 ![Include query from file](./img/external-query.png)
 
 > **Note:**
-> 
+>
 > If you change the cell content and save the notebook then the content of the file will be updated.
+
+## SHACL Validation
+
+In addition to SPARQL, the notebook supports **SHACL validation** against remote SPARQL endpoints that provide a SHACL validation service (such as Apache Jena Fuseki).
+
+### How SHACL Works in the Notebook
+
+SHACL (Shapes Constraint Language) is used to validate RDF graphs against a set of conditions (shapes). In the notebook:
+
+1. Create a code cell and change the language from `sparql` to `shacl`
+2. Write your SHACL shapes in Turtle syntax
+3. Specify the endpoint URL (including any required parameters like the target graph)
+4. Execute the cell to see the validation report
+
+### Configuring SHACL Endpoints
+
+SHACL validation requires specifying the full endpoint URL, including any parameters required by your SHACL service. Use the `[endpoint=...]` comment:
+
+```shacl
+# [endpoint=http://localhost:3030/dataset/shacl?graph=default]
+
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [
+        sh:path ex:name ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] .
+```
+
+### SHACL with Apache Jena Fuseki
+
+Apache Jena Fuseki provides a SHACL validation endpoint. Following the [Jena SHACL documentation](https://jena.apache.org/documentation/shacl/), the endpoint URL typically follows this pattern:
+
+```
+http://localhost:3030/<dataset>/shacl?graph=<graph-to-validate>
+```
+
+Where:
+- `<dataset>` is your Fuseki dataset name
+- `<graph-to-validate>` is `default` for the default graph, or a named graph URI
+
+### Binding SHACL Files to Cells
+
+Similar to SPARQL files, you can bind local `.shacl` or `.ttl` files to SHACL cells. Use the "Add Query from File" option in the cell menu and select a SHACL file. Files with `.shacl` or `.ttl` extensions will automatically be recognized as SHACL cells.
+
+> **Note:**
+>
+> SHACL validation is only supported for HTTP/HTTPS endpoints. Local file-based validation is not currently supported.
+
+> **Note:**
+>
+> The validation result is returned in Turtle format, containing the SHACL validation report.
+
+## Markdown Integration
+
+The SPARQL Notebook extension allows you to execute SPARQL and SHACL code blocks directly from any markdown file. This is useful for:
+
+- Documenting queries in README files with executable examples
+- Creating tutorials with runnable code samples
+- Working with existing markdown documentation that contains SPARQL/SHACL snippets
+
+### How to Use Markdown Integration
+
+1. Open any `.md` or `.markdown` file in VS Code
+2. Right-click on the file in the Explorer or use the editor title bar
+3. Select **"Open With..."**
+4. Choose **"SPARQL Markdown Notebook"**
+
+The markdown file will open in a notebook view where:
+- Regular markdown text becomes markdown cells
+- Code blocks with ` ```sparql ` become executable SPARQL cells
+- Code blocks with ` ```shacl ` become executable SHACL cells
+- Other code blocks (e.g., JavaScript, Python) remain as markdown
+
+### Example Markdown with SPARQL
+
+Create a markdown file with SPARQL code blocks:
+
+````markdown
+# My SPARQL Documentation
+
+This query fetches cities from DBpedia:
+
+```sparql
+# [endpoint=https://dbpedia.org/sparql]
+PREFIX dbo: <http://dbpedia.org/ontology/>
+SELECT ?city WHERE { ?city a dbo:City } LIMIT 10
+```
+````
+
+When opened as a SPARQL Markdown Notebook, the code block becomes an executable cell with inline results.
+
+### Configuration
+
+The markdown integration is enabled by default. You can disable it in VS Code settings:
+
+```json
+{
+  "sparqlbook.markdownIntegration.enabled": false
+}
+```
+
+When disabled, the "SPARQL Markdown Notebook" option will not appear in the "Open With..." menu.
+
+### Preserving Markdown Formatting
+
+When you save a file opened as a SPARQL Markdown Notebook, it will be saved back as valid markdown. The structure is preserved:
+- Markdown cells become regular markdown text
+- SPARQL/SHACL cells become fenced code blocks with the appropriate language tag
+
+This means your markdown files remain compatible with any markdown viewer or documentation system.
 
 ## Export to MARKDOWN
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@zazuko/prefixes": "^2.6.1",
         "oxigraph": "^0.5.5",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@types/glob": "^8.1.0",
@@ -33,6 +34,7 @@
         "eslint": "^9.13.0",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
+        "shx": "^0.4.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.1",
         "typescript": "^5.6.3",
@@ -828,6 +830,44 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2295,6 +2335,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
@@ -2660,12 +2710,141 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/execa/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2698,6 +2877,16 @@
       ],
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2901,6 +3090,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/glob": {
@@ -3186,6 +3388,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
@@ -3222,6 +3434,22 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3342,6 +3570,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-typed-array": {
@@ -3691,6 +3929,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3757,6 +4005,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3926,6 +4184,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -3944,6 +4209,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3955,6 +4243,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -4109,6 +4407,16 @@
       "integrity": "sha512-MRnSBaOGzy8k8xhloTZSoTf4KbPKSbtB++K4BiS+mAqyevVOOgE2fJIbI9e2kYbP3G045Lb3HhbJM8NjbQDfKA==",
       "license": "MIT OR Apache-2.0"
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4194,6 +4502,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -4372,6 +4687,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4397,6 +4723,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -4462,6 +4809,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4481,6 +4840,27 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -4508,6 +4888,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -4674,6 +5089,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.4.0.tgz",
+      "integrity": "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "shelljs": "^0.9.2"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/side-channel": {
@@ -4935,6 +5386,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4976,6 +5437,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tapable": {
@@ -5157,6 +5631,12 @@
         "typescript": "*",
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5542,6 +6022,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "Data Science"
   ],
   "keywords": [
-    "sparql"
+    "sparql",
+    "shacl"
   ],
   "activationEvents": [
-    "onNotebook:sparql-notebook"
+    "onNotebook:sparql-notebook",
+    "onNotebook:sparql-markdown-notebook"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -33,6 +35,20 @@
         "selector": [
           {
             "filenamePattern": "*.sparqlbook"
+          }
+        ]
+      },
+      {
+        "id": "sparql-markdown-notebook",
+        "type": "sparql-markdown-notebook",
+        "displayName": "SPARQL Markdown Notebook",
+        "priority": "option",
+        "selector": [
+          {
+            "filenamePattern": "*.md"
+          },
+          {
+            "filenamePattern": "*.markdown"
           }
         ]
       }
@@ -170,6 +186,11 @@
             "type": "boolean",
             "default": true,
             "description": "Format output using prefixes from query."
+          },
+          "sparqlbook.markdownIntegration.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable SPARQL/SHACL notebook functionality for markdown files. When enabled, you can open markdown files with 'Open With...' and select 'SPARQL Markdown Notebook' to execute SPARQL and SHACL code blocks."
           }
         }
       }
@@ -178,16 +199,16 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "test": "tsc -p src/test/tsconfig.json && vscode-test",
-    "compile": "npm run clean && npm run copy:oxigraph &&npm run esbuild",
+    "compile": "npm run clean && npm run copy:oxigraph && npm run esbuild",
     "lint": "eslint src --ext ts",
     "deploy": "npx vsce publish",
     "package": "npx vsce package",
     "build:extension": "esbuild ./src/extension/extension.ts --sourcemap --minify --bundle --platform=node --external:vscode --external:pg-native --outfile=./out/extension.js",
     "build:renderer": "esbuild ./src/renderer/sparql-result-json.tsx --sourcemap --minify --jsx=automatic --tsconfig=./src/renderer/tsconfig.json --sourcemap --bundle --format=esm --platform=browser --outfile=./out/renderer/sparql-result-json.js",
-    "build:webview": "cd src/webview/endpoint/endpoint-view && npm run build && rm -rf ../../../../out/webview/ && mkdir -p ../../../../out/webview/ && mv dist/endpoint-view ../../../../out/webview/ ",
-    "copy:oxigraph": "cp node_modules/oxigraph/node_bg.wasm out/",
+    "build:webview": "cd src/webview/endpoint/endpoint-view && npm install && npx ng build && npx shx rm -rf ../../../../out/webview/ && npx shx mkdir -p ../../../../out/webview/ && npx shx mv dist/endpoint-view ../../../../out/webview/",
+    "copy:oxigraph": "npx shx cp node_modules/oxigraph/node_bg.wasm out/",
     "esbuild": "npm run build:extension && npm run build:renderer && npm run build:webview",
-    "clean": "rm -rf out/ && mkdir out/"
+    "clean": "npx shx rm -rf out/ && npx shx mkdir out/"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",
@@ -208,6 +229,7 @@
     "eslint": "^9.13.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
+    "shx": "^0.4.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.1",
     "typescript": "^5.6.3",
@@ -218,9 +240,10 @@
     "@zazuko/prefixes": "^2.6.1",
     "oxigraph": "^0.5.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "tslib": "^2.8.1"
   },
   "extensionDependencies": [
-    "vemonet.stardog-rdf-grammars"
+    "stardog-union.stardog-rdf-grammars"
   ]
 }

--- a/samples/example-sparql-markdown.md
+++ b/samples/example-sparql-markdown.md
@@ -1,0 +1,83 @@
+# SPARQL Markdown Notebook Example
+
+This markdown file demonstrates the SPARQL Notebook markdown integration.
+You can execute SPARQL and SHACL code blocks directly from this file.
+
+## How to Use
+
+1. Right-click on this file in VS Code Explorer
+2. Select "Open With..."
+3. Choose "SPARQL Markdown Notebook"
+4. Click the play button next to any SPARQL or SHACL code block to execute it
+
+## Example SPARQL Query
+
+The following query retrieves data from a SPARQL endpoint.
+Make sure you're connected to a SPARQL endpoint first.
+
+```sparql
+# [endpoint=https://dbpedia.org/sparql]
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?city ?name ?population
+WHERE {
+  ?city a dbo:City ;
+        rdfs:label ?name ;
+        dbo:populationTotal ?population .
+  FILTER(lang(?name) = "en")
+}
+ORDER BY DESC(?population)
+LIMIT 10
+```
+
+## Another SPARQL Query
+
+You can have multiple SPARQL blocks in the same markdown file:
+
+```sparql
+# [endpoint=https://dbpedia.org/sparql]
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ASK {
+  ?city a dbo:City .
+}
+```
+
+## SHACL Validation Example
+
+You can also include SHACL validation blocks:
+
+```shacl
+# [endpoint=http://localhost:3030/dataset/shacl?graph=default]
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [
+        sh:path ex:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+    ] .
+```
+
+## Non-executable Code Blocks
+
+Code blocks with other languages will remain as regular markdown:
+
+```javascript
+console.log("This is just regular JavaScript code");
+```
+
+```python
+print("This is just regular Python code")
+```
+
+## Notes
+
+- Results appear inline below each code cell
+- You can specify endpoints per code block using `# [endpoint=...]` comments
+- The file remains valid markdown and can be viewed normally in any markdown viewer

--- a/src/extension/endpoint/endpoint.ts
+++ b/src/extension/endpoint/endpoint.ts
@@ -9,6 +9,7 @@ import { SparqlQuery } from "./model/sparql-query";
 export abstract class Endpoint {
     public abstract url: string;
     abstract query(sparqlQuery: SparqlQuery, execution?: any): Promise<SimpleHttpResponse> | never;
+    abstract validate(shaclGraphAsTurtle: string, execution?: any): Promise<SimpleHttpResponse>;
     abstract readonly isQLeverEndpoint: boolean;
 }
 

--- a/src/extension/endpoint/file-endpoint/file-endpoint.ts
+++ b/src/extension/endpoint/file-endpoint/file-endpoint.ts
@@ -133,4 +133,13 @@ export class FileEndpoint extends Endpoint {
                 return undefined;
         }
     }
+
+    /**
+     * SHACL validation is not supported for file endpoint.
+     * @param shaclGraphAsTurtle - The SHACL graph in Turtle format.
+     * @param execution - The execution object.
+     */
+    public async validate(shaclGraphAsTurtle: string, execution?: any): Promise<SimpleHttpResponse> {
+        throw new Error("SHACL validation is not supported for file endpoints.");
+    }
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -3,7 +3,8 @@ import * as vscode from "vscode";
 import { SparqlNotebookController } from "./notebook/sparql-notebook-controller";
 import { EndpointConnectionTreeDataProvider } from "./sparql-connection-menu/endpoint-tree-data-provider.class";
 
-import { SparqlNotebookSerializer } from "./notebook/file-io";
+import { SparqlNotebookSerializer, MarkdownNotebookSerializer } from "./notebook/file-io";
+import { MarkdownNotebookController, markdownNotebookType } from "./notebook/markdown-notebook-controller";
 
 import { deleteConnection } from "./commands/sparql-connection/delete-connection";
 import { addConnection } from "./commands/sparql-connection/add-connection";
@@ -59,6 +60,24 @@ export async function activate(context: vscode.ExtensionContext) {
   // register the notebook controller
   const sparqlNotebookController = new SparqlNotebookController();
   context.subscriptions.push(sparqlNotebookController);
+
+  // Register markdown notebook integration if enabled
+  const markdownConfig = vscode.workspace.getConfiguration("sparqlbook");
+  const markdownIntegrationEnabled = markdownConfig.get("markdownIntegration.enabled", true);
+
+  if (markdownIntegrationEnabled) {
+    // register the markdown notebook serializer
+    context.subscriptions.push(
+      vscode.workspace.registerNotebookSerializer(
+        markdownNotebookType,
+        new MarkdownNotebookSerializer()
+      )
+    );
+
+    // register the markdown notebook controller
+    const markdownNotebookController = new MarkdownNotebookController();
+    context.subscriptions.push(markdownNotebookController);
+  }
 
   // register the cell status bar item provider
   context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider(extensionId, sparqlNotebookCellStatusBarItemProvider));

--- a/src/extension/notebook/file-io/index.ts
+++ b/src/extension/notebook/file-io/index.ts
@@ -1,1 +1,2 @@
 export { SparqlNotebookSerializer } from './sparql-notebook-serializer.class';
+export { MarkdownNotebookSerializer } from './markdown-notebook-serializer.class';

--- a/src/extension/notebook/file-io/markdown-notebook-serializer.class.ts
+++ b/src/extension/notebook/file-io/markdown-notebook-serializer.class.ts
@@ -1,0 +1,175 @@
+import * as vscode from "vscode";
+import { TextDecoder, TextEncoder } from "util";
+
+/**
+ * Interface representing a parsed markdown section
+ */
+interface MarkdownSection {
+    type: 'markdown' | 'code';
+    content: string;
+    language?: string;
+}
+
+/**
+ * Markdown Notebook Serializer
+ *
+ * This class is responsible for serializing and deserializing markdown files as notebooks.
+ * It parses markdown content and converts fenced code blocks with 'sparql' or 'shacl'
+ * language identifiers into executable code cells.
+ */
+export class MarkdownNotebookSerializer implements vscode.NotebookSerializer {
+
+    /**
+     * Parses markdown content into sections (markdown text and code blocks)
+     *
+     * @param content - The raw markdown content
+     * @returns Array of parsed sections
+     */
+    private parseMarkdown(content: string): MarkdownSection[] {
+        const sections: MarkdownSection[] = [];
+        const lines = content.split(/\r?\n/);
+
+        let currentMarkdown: string[] = [];
+        let currentCode: string[] = [];
+        let inCodeBlock = false;
+        let codeLanguage = '';
+
+        for (const line of lines) {
+            // Check for code fence start
+            const codeFenceStart = line.match(/^```(\w*)$/i);
+
+            if (codeFenceStart && !inCodeBlock) {
+                // Save any accumulated markdown
+                if (currentMarkdown.length > 0) {
+                    const markdownContent = currentMarkdown.join('\n').trim();
+                    if (markdownContent) {
+                        sections.push({
+                            type: 'markdown',
+                            content: markdownContent
+                        });
+                    }
+                    currentMarkdown = [];
+                }
+
+                inCodeBlock = true;
+                codeLanguage = codeFenceStart[1].toLowerCase();
+                currentCode = [];
+            } else if (line.match(/^```$/) && inCodeBlock) {
+                // End of code block
+                const codeContent = currentCode.join('\n');
+
+                // Only create code cells for SPARQL and SHACL
+                if (codeLanguage === 'sparql' || codeLanguage === 'shacl') {
+                    sections.push({
+                        type: 'code',
+                        content: codeContent,
+                        language: codeLanguage
+                    });
+                } else {
+                    // For other languages, keep as markdown with the fence
+                    const fencedCode = '```' + codeLanguage + '\n' + codeContent + '\n```';
+                    sections.push({
+                        type: 'markdown',
+                        content: fencedCode
+                    });
+                }
+
+                inCodeBlock = false;
+                codeLanguage = '';
+                currentCode = [];
+            } else if (inCodeBlock) {
+                currentCode.push(line);
+            } else {
+                currentMarkdown.push(line);
+            }
+        }
+
+        // Handle any remaining content
+        if (inCodeBlock) {
+            // Unclosed code block - treat as markdown
+            const unclosedBlock = '```' + codeLanguage + '\n' + currentCode.join('\n');
+            currentMarkdown.push(unclosedBlock);
+        }
+
+        if (currentMarkdown.length > 0) {
+            const markdownContent = currentMarkdown.join('\n').trim();
+            if (markdownContent) {
+                sections.push({
+                    type: 'markdown',
+                    content: markdownContent
+                });
+            }
+        }
+
+        return sections;
+    }
+
+    /**
+     * Implementation of the deserializeNotebook method.
+     * Converts markdown content into notebook cells.
+     *
+     * @param content - The raw file content
+     * @param _token - Cancellation token
+     * @returns NotebookData with parsed cells
+     */
+    async deserializeNotebook(
+        content: Uint8Array,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.NotebookData> {
+        const markdownContent = new TextDecoder().decode(content);
+        const sections = this.parseMarkdown(markdownContent);
+
+        const cells: vscode.NotebookCellData[] = sections.map(section => {
+            if (section.type === 'code') {
+                return new vscode.NotebookCellData(
+                    vscode.NotebookCellKind.Code,
+                    section.content,
+                    section.language || 'sparql'
+                );
+            } else {
+                return new vscode.NotebookCellData(
+                    vscode.NotebookCellKind.Markup,
+                    section.content,
+                    'markdown'
+                );
+            }
+        });
+
+        return new vscode.NotebookData(cells);
+    }
+
+    /**
+     * Implementation of the serializeNotebook method.
+     * Converts notebook cells back to markdown format.
+     *
+     * @param data - The notebook data to serialize
+     * @param _token - Cancellation token
+     * @returns Serialized markdown content
+     */
+    async serializeNotebook(
+        data: vscode.NotebookData,
+        _token: vscode.CancellationToken
+    ): Promise<Uint8Array> {
+        const parts: string[] = [];
+
+        for (const cell of data.cells) {
+            if (cell.kind === vscode.NotebookCellKind.Code) {
+                // Wrap code cells in fenced code blocks
+                const language = cell.languageId || 'sparql';
+                parts.push('```' + language);
+                parts.push(cell.value);
+                parts.push('```');
+                parts.push(''); // Empty line after code block
+            } else {
+                // Markup cells are added as-is
+                parts.push(cell.value);
+                parts.push(''); // Empty line after markdown section
+            }
+        }
+
+        // Join with newlines and trim trailing whitespace
+        const markdown = parts.join('\n').replace(/\n+$/, '\n');
+
+        return new TextEncoder().encode(markdown);
+    }
+}

--- a/src/extension/notebook/markdown-notebook-controller.ts
+++ b/src/extension/notebook/markdown-notebook-controller.ts
@@ -1,0 +1,69 @@
+import { NotebookCell, NotebookController, NotebookDocument, notebooks, workspace } from 'vscode';
+import { NotebookCellExecutor } from './notebook-cell-executor';
+
+export const markdownNotebookType = "sparql-markdown-notebook";
+
+/**
+ * Controller for executing SPARQL and SHACL code blocks in markdown files.
+ *
+ * This controller handles the execution of code cells when markdown files
+ * are opened as SPARQL Markdown Notebooks.
+ */
+export class MarkdownNotebookController {
+    readonly controllerId = `${markdownNotebookType}-controller-id`;
+    readonly notebookType = markdownNotebookType;
+    readonly label = "SPARQL Markdown Notebook";
+    readonly supportedLanguages = ["sparql", "shacl"];
+
+    readonly #controller: NotebookController;
+    readonly #executor: NotebookCellExecutor;
+    #executionOrder = 0;
+
+    constructor() {
+        // Check if markdown integration is enabled
+        const config = workspace.getConfiguration("sparqlbook");
+        const isEnabled = config.get("markdownIntegration.enabled", true);
+
+        // Create a new notebook controller
+        this.#controller = notebooks.createNotebookController(
+            this.controllerId,
+            this.notebookType,
+            this.label
+        );
+
+        // controller setup
+        this.#controller.supportedLanguages = this.supportedLanguages;
+        this.#controller.supportsExecutionOrder = true;
+        this.#controller.description = "Execute SPARQL and SHACL queries from markdown code blocks";
+
+        // Initialize the shared executor
+        this.#executor = new NotebookCellExecutor();
+
+        // this is executing the cells
+        this.#controller.executeHandler = this.#execute.bind(this);
+    }
+
+    /**
+     * Executes the given cells by calling the executor for each cell.
+     * @param cells - The cells to execute.
+     * @param _notebook - The notebook document containing the cells.
+     * @param _controller - The notebook controller for the notebook document.
+     */
+    #execute(cells: NotebookCell[], _notebook: NotebookDocument, _controller: NotebookController): void {
+        for (let cell of cells) {
+            this.#executeCell(cell);
+        }
+    }
+
+    async #executeCell(nbCell: NotebookCell): Promise<void> {
+        const execution = this.#controller.createNotebookCellExecution(nbCell);
+        execution.executionOrder = ++this.#executionOrder;
+        execution.start(Date.now());
+
+        await this.#executor.executeCell(nbCell, execution);
+    }
+
+    dispose() {
+        this.#controller.dispose();
+    }
+}

--- a/src/extension/notebook/notebook-cell-executor.ts
+++ b/src/extension/notebook/notebook-cell-executor.ts
@@ -1,0 +1,114 @@
+import { NotebookCell, NotebookCellExecution } from 'vscode';
+import { SparqlNotebookCell } from './sparql-notebook-cell';
+import { SparqlQueryHandler } from '../sparql-query-handler/sparql-query-handler';
+import { SelectQueryHandler } from '../sparql-query-handler/select-query-handler';
+import { AskQueryHandler } from '../sparql-query-handler/ask-query-handler';
+import { UpdateQueryHandler } from '../sparql-query-handler/update-query-handler';
+import { ErrorQueryHandler } from '../sparql-query-handler/error-query-handler';
+import { ConstructQueryHandler } from '../sparql-query-handler/construct-query-handler';
+import { ShaclQueryHandler } from '../sparql-query-handler/shacl-query-handler';
+import { writeError } from '../sparql-query-handler/helper/write-error';
+import { SPARQLQueryKind } from '../const/enum/sparql-query-kind';
+import { HttpErrorStatus, HttpSuccessStatus } from '../endpoint/const/http-status';
+import { EndpointResolver } from './endpoint-resolver';
+import { NotebookErrorRenderer } from './notebook-error-renderer';
+
+/**
+ * Shared execution logic for SPARQL/SHACL notebook cells.
+ * This class handles the actual execution of cells and can be used by different notebook controllers.
+ */
+export class NotebookCellExecutor {
+
+    private endpointResolver: EndpointResolver;
+    private errorRenderer: NotebookErrorRenderer;
+
+    constructor() {
+        this.endpointResolver = new EndpointResolver();
+        this.errorRenderer = new NotebookErrorRenderer();
+    }
+
+    /**
+     * Executes a single notebook cell containing SPARQL or SHACL code.
+     *
+     * @param nbCell - The notebook cell to execute
+     * @param execution - The cell execution context
+     */
+    async executeCell(nbCell: NotebookCell, execution: NotebookCellExecution): Promise<void> {
+        const sparqlCell = new SparqlNotebookCell(nbCell);
+        const languageId = nbCell.document.languageId;
+
+        const sparqlQuery = sparqlCell.sparqlQuery;
+        const notebookUri = nbCell.notebook.uri;
+        const sparqlEndpoint = await this.endpointResolver.getDocumentOrConnectionClient(sparqlQuery, notebookUri);
+
+        if (sparqlEndpoint === null) {
+            this.errorRenderer.showConnectionErrorMessage(sparqlQuery, execution);
+            execution.end(false, Date.now());
+            return;
+        }
+
+        let queryResult;
+
+        if (languageId === "shacl") {
+            // SHACL validation - use the raw text and call validate()
+            const shaclText = nbCell.document.getText();
+            queryResult = await sparqlEndpoint.validate(shaclText, execution).catch(
+                (error) => {
+                    this.errorRenderer.showNetworkErrorMessage(error, execution);
+                    execution.end(false, Date.now());
+                    return undefined;
+                });
+        } else {
+            // SPARQL query - use the SparqlQuery object
+            queryResult = await sparqlEndpoint.query(sparqlQuery, execution).catch(
+                (error) => {
+                    this.errorRenderer.showNetworkErrorMessage(error, execution);
+                    execution.end(false, Date.now());
+                    return undefined;
+                });
+        }
+
+        if (!queryResult) {
+            execution.replaceOutput([
+                writeError('No result')
+            ]);
+            execution.end(false, Date.now());
+            return;
+        }
+
+        if (queryResult.status === HttpErrorStatus.BadRequest) {
+            this.errorRenderer.showHttpErrorMessage(queryResult, 'Bad Request', sparqlEndpoint, execution);
+            execution.end(false, Date.now());
+            return;
+        }
+
+        if (queryResult.status !== HttpSuccessStatus.OK && queryResult.status !== HttpSuccessStatus.NoContent) {
+            this.errorRenderer.showHttpErrorMessage(queryResult, queryResult.statusText || 'Error', sparqlEndpoint, execution);
+            writeError(`SPARQL query failed: ${queryResult.status ?? ''} ${queryResult.statusText ?? ''} ${queryResult.data ?? ''}`);
+            execution.end(false, Date.now());
+            return;
+        }
+
+        // Get the appropriate handler based on language or query type
+        const handler = languageId === "shacl"
+            ? new ShaclQueryHandler()
+            : this.#getHandlerForType(sparqlQuery.kind);
+        handler.handle(queryResult, sparqlCell, execution);
+    }
+
+    #getHandlerForType(type: string): SparqlQueryHandler {
+        switch (type) {
+            case SPARQLQueryKind.select: return new SelectQueryHandler();
+            case SPARQLQueryKind.ask: return new AskQueryHandler();
+            case SPARQLQueryKind.construct: return new ConstructQueryHandler();
+            case SPARQLQueryKind.describe: return new ConstructQueryHandler();
+            case SPARQLQueryKind.insert: return new UpdateQueryHandler();
+            case SPARQLQueryKind.create: return new UpdateQueryHandler();
+            case SPARQLQueryKind.drop: return new UpdateQueryHandler();
+            case SPARQLQueryKind.clear: return new UpdateQueryHandler();
+            case SPARQLQueryKind.delete: return new UpdateQueryHandler();
+            case SPARQLQueryKind.load: return new UpdateQueryHandler();
+            default: return new ErrorQueryHandler();
+        }
+    }
+}

--- a/src/extension/notebook/sparql-notebook-controller.ts
+++ b/src/extension/notebook/sparql-notebook-controller.ts
@@ -1,30 +1,16 @@
-import { NotebookCell, RelativePattern, NotebookCellOutputItem, NotebookController, NotebookDocument, Uri, commands, notebooks, window, workspace, NotebookCellExecution } from 'vscode';
+import { NotebookCell, NotebookController, NotebookDocument, notebooks } from 'vscode';
 import { extensionId } from "../extension";
-import { SparqlNotebookCell } from './sparql-notebook-cell';
-import path = require('path');
-import { SparqlQueryHandler } from '../sparql-query-handler/sparql-query-handler';
-import { SelectQueryHandler } from '../sparql-query-handler/select-query-handler';
-import { AskQueryHandler } from '../sparql-query-handler/ask-query-handler';
-import { UpdateQueryHandler } from '../sparql-query-handler/update-query-handler';
-import { ErrorQueryHandler } from '../sparql-query-handler/error-query-handler';
-import { ConstructQueryHandler } from '../sparql-query-handler/construct-query-handler';
-import { writeError } from '../sparql-query-handler/helper/write-error';
-import { SPARQLQueryKind } from '../const/enum/sparql-query-kind';
-import { HttpErrorStatus, HttpSuccessStatus } from '../endpoint/const/http-status';
-import { EndpointResolver } from './endpoint-resolver';
-import { NotebookErrorRenderer } from './notebook-error-renderer';
+import { NotebookCellExecutor } from './notebook-cell-executor';
 
 export class SparqlNotebookController {
   readonly controllerId = `${extensionId}-controller-id`;
   readonly notebookType = extensionId;
   readonly label = "Sparql Notebook";
-  readonly supportedLanguages = ["sparql"];
+  readonly supportedLanguages = ["sparql", "shacl"];
 
   readonly #controller: NotebookController;
+  readonly #executor: NotebookCellExecutor;
   #executionOrder = 0;
-
-  private endpointResolver: EndpointResolver;
-  private errorRenderer: NotebookErrorRenderer;
 
   constructor() {
     // Create a new notebook controller
@@ -38,15 +24,15 @@ export class SparqlNotebookController {
     this.#controller.supportedLanguages = this.supportedLanguages;
     this.#controller.supportsExecutionOrder = true;
 
+    // Initialize the shared executor
+    this.#executor = new NotebookCellExecutor();
+
     // this is executing the cells
     this.#controller.executeHandler = this.#execute.bind(this);
-
-    this.endpointResolver = new EndpointResolver();
-    this.errorRenderer = new NotebookErrorRenderer();
   }
 
   /**
-   * Executes the given cells by calling the _doExecution method for each cell.
+   * Executes the given cells by calling the executor for each cell.
    * @param cells - The cells to execute.
    * @param _notebook - The notebook document containing the cells.
    * @param _controller - The notebook controller for the notebook document.
@@ -57,77 +43,15 @@ export class SparqlNotebookController {
     }
   }
 
-
   async #executeCell(nbCell: NotebookCell): Promise<void> {
-
-    const sparqlCell = new SparqlNotebookCell(nbCell);
-
-    const execution = this.#controller.createNotebookCellExecution(sparqlCell.cell);
+    const execution = this.#controller.createNotebookCellExecution(nbCell);
     execution.executionOrder = ++this.#executionOrder;
     execution.start(Date.now());
 
-    const sparqlQuery = sparqlCell.sparqlQuery;
-    const notebookUri = nbCell.notebook.uri;
-    const sparqlEndpoint = await this.endpointResolver.getDocumentOrConnectionClient(sparqlQuery, notebookUri);
-
-    if (sparqlEndpoint === null) {
-      this.errorRenderer.showConnectionErrorMessage(sparqlQuery, execution);
-      execution.end(false, Date.now());
-      return;
-    }
-
-    // run the query
-    const queryResult = await sparqlEndpoint.query(sparqlQuery, execution).catch(
-      (error) => {
-        this.errorRenderer.showNetworkErrorMessage(error, execution);
-        execution.end(false, Date.now());
-        return;
-      });
-
-    if (!queryResult) {
-      execution.replaceOutput([
-        writeError('No result')
-      ]);
-      execution.end(false, Date.now());
-      return;
-    }
-
-    if (queryResult.status === HttpErrorStatus.BadRequest) {
-      this.errorRenderer.showHttpErrorMessage(queryResult, 'Bad Request', sparqlEndpoint, execution);
-      execution.end(false, Date.now());
-      return;
-    }
-
-    if (queryResult.status !== HttpSuccessStatus.OK && queryResult.status !== HttpSuccessStatus.NoContent) {
-      this.errorRenderer.showHttpErrorMessage(queryResult, queryResult.statusText || 'Error', sparqlEndpoint, execution);
-      writeError(`SPARQL query failed: ${queryResult.status ?? ''} ${queryResult.statusText ?? ''} ${queryResult.data ?? ''}`);
-      execution.end(false, Date.now());
-      return;
-    }
-
-
-    const handler = this.#getHandlerForType(sparqlQuery.kind);
-    handler.handle(queryResult, sparqlCell, execution);
+    await this.#executor.executeCell(nbCell, execution);
   }
 
   dispose() {
     this.#controller.dispose();
   }
-
-  #getHandlerForType(type: string): SparqlQueryHandler {
-    switch (type) {
-      case SPARQLQueryKind.select: return new SelectQueryHandler();
-      case SPARQLQueryKind.ask: return new AskQueryHandler();
-      case SPARQLQueryKind.construct: return new ConstructQueryHandler();
-      case SPARQLQueryKind.describe: return new ConstructQueryHandler();
-      case SPARQLQueryKind.insert: return new UpdateQueryHandler();
-      case SPARQLQueryKind.create: return new UpdateQueryHandler();
-      case SPARQLQueryKind.drop: return new UpdateQueryHandler();
-      case SPARQLQueryKind.clear: return new UpdateQueryHandler();
-      case SPARQLQueryKind.delete: return new UpdateQueryHandler();
-      case SPARQLQueryKind.load: return new UpdateQueryHandler();
-      default: return new ErrorQueryHandler();
-    }
-  }
-
 }

--- a/src/extension/sparql-query-handler/shacl-query-handler.ts
+++ b/src/extension/sparql-query-handler/shacl-query-handler.ts
@@ -1,0 +1,26 @@
+import { NotebookCellExecution } from "vscode";
+import { SimpleHttpResponse } from "../endpoint/endpoint";
+import { SparqlNotebookCell } from "../notebook/sparql-notebook-cell";
+import { SparqlQueryHandler } from "./sparql-query-handler";
+import { writeTurtleResult } from "./helper/write-turtle-result";
+
+/**
+ * Handler for SHACL validation results.
+ * SHACL validation returns turtle format containing the validation report.
+ */
+export class ShaclQueryHandler implements SparqlQueryHandler {
+    constructor() { }
+
+    /**
+     * Handle the result of a SHACL validation.
+     *
+     * @param queryResult The result of the SHACL validation (turtle format).
+     * @param _sparqlCell The SHACL notebook cell.
+     * @param execution The notebook cell execution context.
+     */
+    handle(queryResult: SimpleHttpResponse, _sparqlCell: SparqlNotebookCell, execution: NotebookCellExecution) {
+        const cell = writeTurtleResult(queryResult.data);
+        execution.replaceOutput([cell]);
+        execution.end(true, Date.now());
+    }
+}

--- a/src/test/markdown-notebook.test.ts
+++ b/src/test/markdown-notebook.test.ts
@@ -1,0 +1,312 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+suite('Markdown Notebook Serializer Test Suite', () => {
+    let tmpDir: string;
+
+    setup(async () => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-sparql-markdown-test-'));
+    });
+
+    teardown(async () => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    });
+
+    test('Parses markdown with SPARQL code block into notebook cells', async () => {
+        const markdownContent = `# Test Document
+
+This is some introductory text.
+
+\`\`\`sparql
+SELECT * WHERE { ?s ?p ?o }
+\`\`\`
+
+Some more text after the query.
+`;
+        const markdownFile = 'test.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), markdownContent);
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+
+        // Should have 3 cells: markdown, code, markdown
+        assert.strictEqual(document.cellCount, 3, 'Should have 3 cells');
+
+        // First cell should be markdown
+        const cell1 = document.cellAt(0);
+        assert.strictEqual(cell1.kind, vscode.NotebookCellKind.Markup, 'First cell should be markup');
+        assert.ok(cell1.document.getText().includes('# Test Document'), 'First cell should contain title');
+
+        // Second cell should be SPARQL code
+        const cell2 = document.cellAt(1);
+        assert.strictEqual(cell2.kind, vscode.NotebookCellKind.Code, 'Second cell should be code');
+        assert.strictEqual(cell2.document.languageId, 'sparql', 'Second cell language should be sparql');
+        assert.ok(cell2.document.getText().includes('SELECT * WHERE'), 'Second cell should contain SPARQL query');
+
+        // Third cell should be markdown
+        const cell3 = document.cellAt(2);
+        assert.strictEqual(cell3.kind, vscode.NotebookCellKind.Markup, 'Third cell should be markup');
+        assert.ok(cell3.document.getText().includes('Some more text'), 'Third cell should contain trailing text');
+    });
+
+    test('Parses markdown with SHACL code block into notebook cells', async () => {
+        const markdownContent = `# SHACL Test
+
+\`\`\`shacl
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person .
+\`\`\`
+`;
+        const markdownFile = 'shacl-test.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), markdownContent);
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+
+        // Should have 2 cells: markdown, code
+        assert.strictEqual(document.cellCount, 2, 'Should have 2 cells');
+
+        // Second cell should be SHACL code
+        const cell2 = document.cellAt(1);
+        assert.strictEqual(cell2.kind, vscode.NotebookCellKind.Code, 'Second cell should be code');
+        assert.strictEqual(cell2.document.languageId, 'shacl', 'Second cell language should be shacl');
+        assert.ok(cell2.document.getText().includes('sh:NodeShape'), 'Second cell should contain SHACL shape');
+    });
+
+    test('Keeps non-SPARQL/SHACL code blocks as markdown', async () => {
+        const markdownContent = `# Code Examples
+
+JavaScript example:
+
+\`\`\`javascript
+console.log("Hello");
+\`\`\`
+
+Python example:
+
+\`\`\`python
+print("Hello")
+\`\`\`
+`;
+        const markdownFile = 'other-code.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), markdownContent);
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+
+        // All content should be in markup cells since no SPARQL/SHACL
+        for (let i = 0; i < document.cellCount; i++) {
+            const cell = document.cellAt(i);
+            assert.strictEqual(cell.kind, vscode.NotebookCellKind.Markup, `Cell ${i} should be markup`);
+        }
+    });
+
+    test('Parses mixed SPARQL and SHACL code blocks', async () => {
+        const markdownContent = `# Mixed Document
+
+SPARQL query:
+
+\`\`\`sparql
+SELECT ?s WHERE { ?s a ?type }
+\`\`\`
+
+SHACL shape:
+
+\`\`\`shacl
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Shape a sh:NodeShape .
+\`\`\`
+
+Another SPARQL query:
+
+\`\`\`sparql
+ASK { ?s ?p ?o }
+\`\`\`
+`;
+        const markdownFile = 'mixed.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), markdownContent);
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+
+        // Count code cells
+        let sparqlCount = 0;
+        let shaclCount = 0;
+        for (let i = 0; i < document.cellCount; i++) {
+            const cell = document.cellAt(i);
+            if (cell.kind === vscode.NotebookCellKind.Code) {
+                if (cell.document.languageId === 'sparql') {
+                    sparqlCount++;
+                } else if (cell.document.languageId === 'shacl') {
+                    shaclCount++;
+                }
+            }
+        }
+
+        assert.strictEqual(sparqlCount, 2, 'Should have 2 SPARQL cells');
+        assert.strictEqual(shaclCount, 1, 'Should have 1 SHACL cell');
+    });
+
+    test('Handles case-insensitive language identifiers', async () => {
+        const markdownContent = `# Case Test
+
+\`\`\`SPARQL
+SELECT * WHERE { ?s ?p ?o }
+\`\`\`
+
+\`\`\`Shacl
+ex:Shape a sh:NodeShape .
+\`\`\`
+`;
+        const markdownFile = 'case-test.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), markdownContent);
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+
+        // Should recognize both as code cells despite different casing
+        let codeCount = 0;
+        for (let i = 0; i < document.cellCount; i++) {
+            const cell = document.cellAt(i);
+            if (cell.kind === vscode.NotebookCellKind.Code) {
+                codeCount++;
+            }
+        }
+
+        assert.strictEqual(codeCount, 2, 'Should have 2 code cells regardless of case');
+    });
+
+    test('Executes SPARQL query from markdown file against file endpoint', async () => {
+        // Create a Turtle file with sample RDF data
+        const dataFile = 'data.ttl';
+        const turtleData = `@prefix ex: <http://example.org/> .
+
+ex:subject ex:predicate "markdown test value" .
+`;
+        fs.writeFileSync(path.join(tmpDir, dataFile), turtleData);
+
+        // Create markdown file with SPARQL query
+        const markdownContent = `# Query Test
+
+\`\`\`sparql
+# [endpoint=${dataFile}]
+
+SELECT ?s ?p ?o WHERE {
+    ?s ?p ?o
+}
+\`\`\`
+`;
+        const markdownFile = 'query-test.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), markdownContent);
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+        await vscode.window.showNotebookDocument(document);
+
+        // Find the code cell
+        let codeCell: vscode.NotebookCell | undefined;
+        for (let i = 0; i < document.cellCount; i++) {
+            const cell = document.cellAt(i);
+            if (cell.kind === vscode.NotebookCellKind.Code) {
+                codeCell = cell;
+                break;
+            }
+        }
+
+        assert.ok(codeCell, 'Should have a code cell');
+
+        // Execute the cell
+        await vscode.commands.executeCommand('notebook.cell.execute', {
+            ranges: [{ start: codeCell!.index, end: codeCell!.index + 1 }],
+            document: uri
+        });
+
+        // Wait for execution to complete
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                disposable.dispose();
+                reject(new Error('Cell execution timed out'));
+            }, 10000);
+
+            const disposable = vscode.workspace.onDidChangeNotebookDocument(e => {
+                if (e.notebook.uri.toString() === uri.toString()) {
+                    const cell = e.notebook.cellAt(codeCell!.index);
+                    if (cell.outputs.length > 0) {
+                        clearTimeout(timeout);
+                        disposable.dispose();
+                        resolve();
+                    }
+                }
+            });
+
+            // Check if output already exists
+            if (codeCell!.outputs.length > 0) {
+                clearTimeout(timeout);
+                disposable.dispose();
+                resolve();
+            }
+        });
+
+        // Verify the output
+        assert.ok(codeCell!.outputs.length > 0, 'Cell should have output after execution');
+        const output = codeCell!.outputs[0];
+        assert.ok(output.items.length > 0, 'Output should have items');
+
+        // Check for SPARQL results JSON
+        const jsonItem = output.items.find(item => item.mime === 'application/sparql-results+json');
+        assert.ok(jsonItem, 'Output should contain SPARQL results JSON');
+
+        const resultText = new TextDecoder().decode(jsonItem.data);
+        const result = JSON.parse(resultText);
+
+        // Verify the structure of SPARQL results
+        assert.ok(result.head, 'Result should have head');
+        assert.ok(result.results, 'Result should have results');
+        assert.ok(result.results.bindings, 'Result should have bindings');
+
+        // Verify that our test data is in the results
+        const hasTestValue = result.results.bindings.some((binding: any) =>
+            binding.o && binding.o.value === 'markdown test value'
+        );
+        assert.ok(hasTestValue, 'Results should contain the test value from the Turtle file');
+    });
+
+    test('Handles empty markdown file', async () => {
+        const markdownFile = 'empty.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), '');
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+
+        assert.strictEqual(document.cellCount, 0, 'Empty file should have no cells');
+    });
+
+    test('Handles markdown with only text (no code blocks)', async () => {
+        const markdownContent = `# Plain Document
+
+This is just plain text without any code blocks.
+
+## Another Section
+
+More text here.
+`;
+        const markdownFile = 'plain.md';
+        fs.writeFileSync(path.join(tmpDir, markdownFile), markdownContent);
+
+        const uri = vscode.Uri.file(path.join(tmpDir, markdownFile));
+        const document = await vscode.workspace.openNotebookDocument(uri);
+
+        // Should have one markup cell with all the content
+        assert.ok(document.cellCount >= 1, 'Should have at least one cell');
+
+        const cell = document.cellAt(0);
+        assert.strictEqual(cell.kind, vscode.NotebookCellKind.Markup, 'Cell should be markup');
+    });
+});

--- a/src/webview/endpoint/endpoint-view/angular.json
+++ b/src/webview/endpoint/endpoint-view/angular.json
@@ -87,5 +87,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/test/fuseki/config.ttl
+++ b/test/fuseki/config.ttl
@@ -29,17 +29,21 @@
 <#queryService> a fuseki:Service ;
     fuseki:name                     "query" ;
     fuseki:serviceQuery             "sparql" ;
+    fuseki:serviceShacl             "shacl" ;
     fuseki:dataset                  :dataset-ds-owl ;
-    fuseki:readGraphStore           true .
+    fuseki:readGraphStore           true ;
+    fuseki:endpoint [ fuseki:operation fuseki:shacl    ; fuseki:name "shacl"  ] .
 
 # Read-write endpoint (queries + updates)
 <#rwService> a fuseki:Service ;
     fuseki:name                     "rw" ;
     fuseki:serviceQuery             "sparql" ;
     fuseki:serviceUpdate            "update" ;
+    fuseki:serviceShacl             "shacl" ;
     fuseki:dataset                  :dataset-ds-owl ;
     fuseki:readGraphStore           true ;
-    fuseki:updateGraphStore         true .
+    fuseki:updateGraphStore         true ;
+    fuseki:endpoint [ fuseki:operation fuseki:shacl    ; fuseki:name "shacl"  ] .
 
 # Write-only endpoint (updates only)
 <#updateService> a fuseki:Service ;


### PR DESCRIPTION
## Summary

This PR introduces Markdown integration and SHACL (Shapes Constraint Language) support to the SPARQL Notebook extension.

## Changes

- Added Markdown cell support for enhanced documentation within notebooks
- Integrated SHACL validation capabilities for RDF data
- Updated dependencies and configuration

## Testing

- Unit tests updated and passing
- Manual testing performed in VS Code environment

## Notes

- The extension `vemonet.stardog-rdf-grammars` was referenced but not available in the VS Code Marketplace. Switched back to `stardog-union.stardog-rdf-grammars`.
- The SHACL implementation was originally developed over a year ago and has been re-applied to the latest version of the extension using Claude Code assistance.
- The Markdown integration was implemented with Claude Code. The code has been reviewed and appears sound.
- Introduced "shx" to be able to build under any platform including windows.

## Details:
- Created MarkdownNotebookSerializer to parse markdown files into notebook cells
- SPARQL code blocks (```sparql) become executable SPARQL cells
- SHACL code blocks (```shacl) become executable SHACL cells
- Other code blocks remain as markdown content
- Created MarkdownNotebookController for executing cells in markdown notebooks
- Refactored cell execution logic into shared NotebookCellExecutor class
- Added configuration setting sparqlbook.markdownIntegration.enabled (default: true)
- Registered as optional notebook type with priority "option" (use "Open With...")
- Added sample markdown file demonstrating the feature
- Updated documentation with markdown integration instructions

Added tests and updated documentation for markdown integration:
- Added comprehensive test suite for MarkdownNotebookSerializer
- Tests cover SPARQL/SHACL parsing, mixed content, case-insensitive languages
- Tests include execution against file endpoints
- Updated README.md with markdown integration feature documentation
- Added usage instructions and configuration options

Added support for SHACL validation:
- In addition to SPARQL, SHACL is now available as a language in the code blocks.
  - enabling SHACL validation at /rw/shacl?graph=<target-graph>
- SHACL must use the text/turtle syntax.
- The result is in text/turtle format.
- Tested against Apache Jena Fuseki 4.6 SHACL endpoint.
  - Following the guidelines at https://jena.apache.org/documentation/shacl/, the graph to be validated is encoded in the URL. Therefore, for SHACL, I recommend specifying the endpoint configuration as a comment in each code block.
  - Added fuseki:serviceShacl "shacl" to the read-write service endpoint,
- Enable SHACL validation in test Fuseki configuration
- Added tslib as dependency.
- Extended file linking to support .shacl and .ttl files for SHACL cells
- Updated add-query-from-file command to recognize SHACL files and set the correct language ID
- Updated README.md with SHACL features in the feature list
- Added comprehensive SHACL documentation section in doc/00_intro.md covering endpoint configuration, Apache Jena Fuseki integration, and file binding

Users specify the full endpoint URL including any query parameters directly in [endpoint=...]. This is simpler and more flexible since different SHACL endpoints may use different parameter names.